### PR TITLE
Fix spread applying every pierce

### DIFF
--- a/PierceBugFix/PierceSpreadPatch.cs
+++ b/PierceBugFix/PierceSpreadPatch.cs
@@ -1,0 +1,29 @@
+﻿using HarmonyLib;
+using static Weapon;
+using UnityEngine;
+using System.Reflection;
+
+namespace PierceBugFix
+{
+    [HarmonyPatch]
+    internal static class PierceSpreadPatch
+    {
+        [HarmonyTargetMethod]
+        private static MethodBase FindWeaponRayFunc(Harmony harmony)
+        {
+            return AccessTools.Method(
+                typeof(Weapon),
+                nameof(Weapon.CastWeaponRay),
+                new Type[] { typeof(Transform), typeof(Weapon.WeaponHitData).MakeByRefType(), typeof(Vector3), typeof(int) }
+                );
+        }
+
+        [HarmonyPostfix]
+        private static void PostRayCallback(ref WeaponHitData weaponRayData)
+        {
+            weaponRayData.randomSpread = 0;
+            weaponRayData.angOffsetX = 0;
+            weaponRayData.angOffsetY = 0;
+        }
+    }
+}

--- a/PierceBugFix/PierceSpreadPatch.cs
+++ b/PierceBugFix/PierceSpreadPatch.cs
@@ -2,7 +2,6 @@
 using static Weapon;
 using UnityEngine;
 using System.Reflection;
-using System.Numerics;
 
 namespace PierceBugFix
 {
@@ -20,13 +19,11 @@ namespace PierceBugFix
         }
 
         [HarmonyPostfix]
-        private static void PostRayCallback(ref WeaponHitData weaponRayData, bool __result)
+        private static void PostRayCallback(ref WeaponHitData weaponRayData)
         {
             weaponRayData.randomSpread = 0;
             weaponRayData.angOffsetX = 0;
             weaponRayData.angOffsetY = 0;
-            if (!__result)
-                weaponRayData.maxRayDist = 0f;
         }
     }
 }

--- a/PierceBugFix/PierceSpreadPatch.cs
+++ b/PierceBugFix/PierceSpreadPatch.cs
@@ -2,6 +2,7 @@
 using static Weapon;
 using UnityEngine;
 using System.Reflection;
+using System.Numerics;
 
 namespace PierceBugFix
 {
@@ -19,11 +20,13 @@ namespace PierceBugFix
         }
 
         [HarmonyPostfix]
-        private static void PostRayCallback(ref WeaponHitData weaponRayData)
+        private static void PostRayCallback(ref WeaponHitData weaponRayData, bool __result)
         {
             weaponRayData.randomSpread = 0;
             weaponRayData.angOffsetX = 0;
             weaponRayData.angOffsetY = 0;
+            if (!__result)
+                weaponRayData.maxRayDist = 0f;
         }
     }
 }

--- a/PierceBugFix/Plugin.cs
+++ b/PierceBugFix/Plugin.cs
@@ -1,6 +1,7 @@
 ﻿using BepInEx;
 using BepInEx.Unity.IL2CPP;
 using Gear;
+using HarmonyLib;
 using Il2CppInterop.Runtime;
 using Il2CppInterop.Runtime.Runtime;
 using Il2CppInterop.Runtime.Runtime.VersionSpecific.Class;
@@ -10,9 +11,10 @@ using System.Runtime.InteropServices;
 
 namespace PierceBugFix;
 
-[BepInPlugin("tru0067.PierceBugFix", "PierceBugFix", "1.0.0")]
+[BepInPlugin(GUID, "PierceBugFix", "1.0.0")]
 public class Plugin : BasePlugin
 {
+    internal const string GUID = "tru0067.PierceBugFix";
     public const int NOP = 0x90;
     public override unsafe void Load()
     {
@@ -21,6 +23,7 @@ public class Plugin : BasePlugin
 
         PatchBulletWeaponFire<BulletWeapon>(3, 4, 3);
         PatchBulletWeaponFire<Shotgun>(3, 5, 3);
+        new Harmony(GUID).PatchAll();
 
         Logger.Info("PierceBugFix is loaded!");
     }


### PR DESCRIPTION
Fixes bullets re-applying random spread and shotgun offsets with every pierce. Using a harmony patch to fix this issue since there likely isn't a feasible way to do it with a direct patch.

Shotgun creates a new WeaponHitData for every pellet, so it is safe to set these values to 0 without modifying the random spread/offset of other pellets. Confirmed in testing.

Did not test shotgun sentry, but R6Mono uses applicable logic so I highly doubt it will have any issues.